### PR TITLE
tries to fix the GitHub actions error you're seeing

### DIFF
--- a/.github/workflows/deploy-shiny.yml
+++ b/.github/workflows/deploy-shiny.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       SHINYAPPS_TOKEN: ${{ secrets.SHINYAPPS_TOKEN }}
       SHINYAPPS_SECRET: ${{ secrets.SHINYAPPS_SECRET }}
-      GITHUB_PATH: ${{ secrets.GH_PATH }}
+      GITHUB_PAT: ${{ secrets.GH_PATH }}
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
This is the error that the proposed patch tries to fix: https://github.com/munozedg/RiskCalculator/runs/5326596211?check_suite_focus=true#step:6:12

Notice on line 20 of your deploy-shiny.yml you have `GITHUB_PATH: ${{ secrets.GH_PATH }}` . Yes, on the right side you may rename the `secrets.GH_PAT` to `secrets.GH_PATH` _if_ that matches the name you gave to that secret (I don't know if it does because only you can see your settings for this repository).

However, on the left side it has to be named `GITHUB_PAT` because the `install.github()` R command that gets evoked later is hard-coded to look for such an environment variable. It ignores any other spelling variation.

This is in contrast to `SHINYAPPS_TOKEN` and `SHINYAPPS_SECRET` where you can give these environment variables any names you want as long as the `Sys.getenv()` commands further down are updated to the same environment variable names.